### PR TITLE
Configure Django CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,30 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        python manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: [3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# banQuest
+# banQuest  [![Django CI](https://github.com/dosXdev/banQuest/actions/workflows/django.yml/badge.svg)](https://github.com/dosXdev/banQuest/actions/workflows/django.yml)
 One stop Event Space management site
 
 Django backend setup and installation doc [here](https://github.com/dosXdev/banQuest/tree/main/docs/dev-setup.md)


### PR DESCRIPTION
Enables build check for Python versions 3.11 and 3.12. And adds CI status badge to main Readme file.
Automates CI process with unit test verification. Blocks PR merge on test cases fail.